### PR TITLE
stop metrics reporting from dying indefinitely

### DIFF
--- a/src/ninja/natsuko/bot/Main.java
+++ b/src/ninja/natsuko/bot/Main.java
@@ -284,7 +284,6 @@ public class Main {
 						}
 					} catch (InterruptedException | IOException e) {
 						root.error(e.getMessage());
-						break;
 					}
 				}
 			}, "Status Metric Thread").start();


### PR DESCRIPTION
## What does this PR do?
Remove a break which caused the Status Metrics thread to die out on any error, Will now keep trying even if it's failing.

## Why is it good for us?
Statuspage should stop reporting 0ms ping all the time

